### PR TITLE
[BREAKING] Do not mutate node object passed in on selection

### DIFF
--- a/addon/components/node-tree/node/index.hbs
+++ b/addon/components/node-tree/node/index.hbs
@@ -3,7 +3,7 @@
     local-class="row"
     class={{this.customRowClass}}
     style={{this.computedStyle}}
-    data-is-selected={{if this.node.isSelected "true" "false"}}
+    data-is-selected={{if @isSelected "true" "false"}}
     data-is-hidden={{if this.node.isHidden "true" "false"}}
   >
     {{#if this.shouldDisplayChildNodes}}

--- a/addon/components/node-tree/tree/index.hbs
+++ b/addon/components/node-tree/tree/index.hbs
@@ -20,6 +20,7 @@
         @customNodeComponent={{@customNodeComponent}}
         @customRowClass={{@customRowClass}}
         @filterNodesFn={{@filterNodesFn}}
+        @isSelected={{this.isNodeSelected node}}
       />
     {{/animated-each}}
   </AnimatedContainer>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-svg-jar": "^2.3.4",
     "ember-truth-helpers": "^3.0.0",
     "sass": "^1.52.0",
-    "tracked-built-ins": "^2.0.1"
+    "tracked-built-ins": "^3.1.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "ember-element-helper": "^0.6.1",
     "ember-svg-jar": "^2.3.4",
     "ember-truth-helpers": "^3.0.0",
-    "sass": "^1.52.0"
+    "sass": "^1.52.0",
+    "tracked-built-ins": "^2.0.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -4,14 +4,15 @@ const browsers = [
   'last 1 Chrome versions',
   'last 1 Firefox versions',
   'last 1 Safari versions',
+  // running into a bug of ember-animated if not transpiling for IE 11
+  // https://github.com/marcemira/ember-node-tree/pull/38#issuecomment-1168866512
+  //
+  // Using uppercase to bypass tracked-built-ins IE11 detection, which
+  // throws a build-time error that IE11 is not supported. Luckly it
+  // does strict equal of lowercase string.
+  // https://github.com/tracked-tools/tracked-built-ins/commit/c880077875ef5559178dc0918173346c82526801
+  'IE 11',
 ];
-
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
 
 module.exports = {
   browsers,

--- a/tests/integration/components/node-tree-test.js
+++ b/tests/integration/components/node-tree-test.js
@@ -120,7 +120,7 @@ module('Integration | Component | node-tree', function (hooks) {
         .hasAttribute('data-is-selected', 'false');
     });
 
-    test('unselecting a parent node, unselects all child nodes', async function (assert) {
+    test('unselecting a parent node, does not change selection change of child nodes', async function (assert) {
       this.nodeToBeSelected = new Node({
         name: 'target node',
         childNodes: [
@@ -136,18 +136,15 @@ module('Integration | Component | node-tree', function (hooks) {
         </NodeTree>/>
       `);
 
-      // act: select all nodes
-      // Note: selecting parent node unselects child nodes
+      // act: select some nodes
       await click('[data-test-node="target node"] .name');
       await click('[data-test-node="first child node"] .name');
       await click('[data-test-node="other node"] .name');
-      await click('[data-test-node="second child node"] .name');
 
-      // assert: all nodes are selected
+      // assert: nodes are selected
       for (const nodeName of [
         'target node',
         'first child node',
-        'second child node',
         'other node',
       ]) {
         assert
@@ -155,22 +152,25 @@ module('Integration | Component | node-tree', function (hooks) {
           .hasAttribute('data-is-selected', 'true');
       }
 
+      // assert: other nodes are not selected
+      assert
+        .dom('[data-test-node="second child node"] > div')
+        .hasAttribute('data-is-selected', 'false');
+
       await click('[data-test-node="target node"] .name');
-      for (const nodeName of [
-        'target node',
-        'first child node',
-        'second child node',
-      ]) {
+      for (const nodeName of ['target node', 'second child node']) {
         assert
           .dom(`[data-test-node="${nodeName}"] > div`)
           .hasAttribute('data-is-selected', 'false');
       }
-      assert
-        .dom('[data-test-node="other node"] > div')
-        .hasAttribute('data-is-selected', 'true');
+      for (const nodeName of ['first child node', 'other node']) {
+        assert
+          .dom(`[data-test-node="${nodeName}"] > div`)
+          .hasAttribute('data-is-selected', 'true');
+      }
     });
 
-    test('selecting a parent node unselects previously selected child nodes', async function (assert) {
+    test('selecting a parent node does not unselect previously selected child nodes', async function (assert) {
       this.nodes = [
         new Node({
           name: 'parent node',
@@ -194,7 +194,11 @@ module('Integration | Component | node-tree', function (hooks) {
         .hasAttribute('data-is-selected', 'true', 'parent node is selected');
       assert
         .dom('[data-test-node="child node"] > div')
-        .hasAttribute('data-is-selected', 'false', 'child node is unselected');
+        .hasAttribute(
+          'data-is-selected',
+          'true',
+          'child node is still selected'
+        );
     });
 
     test('@onSelection event handler is fired when user clicks on a node', async function (assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,7 +1311,7 @@
     "@handlebars/parser" "~2.0.0"
     simple-html-tokenizer "^0.5.11"
 
-"@glimmer/tracking@^1.0.0", "@glimmer/tracking@^1.0.4", "@glimmer/tracking@^1.1.2":
+"@glimmer/tracking@^1.0.4", "@glimmer/tracking@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-1.1.2.tgz#74e71be07b0a7066518d24044d2665d0cf8281eb"
   integrity sha512-cyV32zsHh+CnftuRX84ALZpd2rpbDrhLhJnTXn9W//QpqdRZ5rdMsxSY9fOsj0CKEc706tmEU299oNnDc0d7tA==
@@ -4991,10 +4991,26 @@ ember-cli-typescript@^3.1.4:
     stagehand "^1.0.0"
     walk-sync "^2.0.0"
 
-ember-cli-typescript@^4.0.0, ember-cli-typescript@^4.1.0, ember-cli-typescript@^4.2.1:
+ember-cli-typescript@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz#54d08fc90318cc986f3ea562f93ce58a6cc4c24d"
   integrity sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==
+  dependencies:
+    ansi-to-html "^0.6.15"
+    broccoli-stew "^3.0.0"
+    debug "^4.0.0"
+    execa "^4.0.0"
+    fs-extra "^9.0.1"
+    resolve "^1.5.0"
+    rsvp "^4.8.1"
+    semver "^7.3.2"
+    stagehand "^1.0.0"
+    walk-sync "^2.2.0"
+
+ember-cli-typescript@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-5.1.0.tgz#460eb848564e29d64f2b36b2a75bbe98172b72a4"
+  integrity sha512-wEZfJPkjqFEZAxOYkiXsDrJ1HY75e/6FoGhQFg8oNFJeGYpIS/3W0tgyl1aRkSEEN1NRlWocDubJ4aZikT+RTA==
   dependencies:
     ansi-to-html "^0.6.15"
     broccoli-stew "^3.0.0"
@@ -5416,7 +5432,7 @@ ember-test-selectors@^6.0.0:
     ember-cli-babel "^7.26.4"
     ember-cli-version-checker "^5.1.2"
 
-ember-tracked-storage-polyfill@1.0.0, ember-tracked-storage-polyfill@^1.0.0:
+ember-tracked-storage-polyfill@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-tracked-storage-polyfill/-/ember-tracked-storage-polyfill-1.0.0.tgz#84d307a1e4badc5f84dca681db2cfea9bdee8a77"
   integrity sha512-eL7lZat68E6P/D7b9UoTB5bB5Oh/0aju0Z7PCMi3aTwhaydRaxloE7TGrTRYU+NdJuyNVZXeGyxFxn2frvd3TA==
@@ -11340,25 +11356,14 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-tracked-built-ins@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/tracked-built-ins/-/tracked-built-ins-2.0.1.tgz#9d6d0db29ad187e8533591f0e891e15b7a2259c5"
-  integrity sha512-v0DwPVNm3zA4cmJLpcBJxJfKefN6ldhkc8l5YA+cWHq7kI8WMUcXjIXgl/AIxmt1SoO1bwPdpikPRHHrIBDtFQ==
+tracked-built-ins@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tracked-built-ins/-/tracked-built-ins-3.1.0.tgz#827703e8e8857e45ac449dfc41e8706e0d6da309"
+  integrity sha512-yPEZV1aYaw7xFWdoEluvdwNxIJIA834HaBQaMATjNAYPwd1fRqIJ46YnuRo6+9mRRWu6nM6sJqrVVa5H6UhFuw==
   dependencies:
     ember-cli-babel "^7.26.10"
-    ember-cli-typescript "^4.1.0"
+    ember-cli-typescript "^5.1.0"
     ember-tracked-storage-polyfill "^1.0.0"
-    tracked-maps-and-sets "^3.0.2"
-
-tracked-maps-and-sets@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/tracked-maps-and-sets/-/tracked-maps-and-sets-3.0.2.tgz#6ea1b9f2a367d24f2e9905b74b24437fbce76ea6"
-  integrity sha512-UIRcWsX1kDOcC/Q2R58weYWlw01EnmWWBwUv3okWS+zMBvsgIfYoO6veHhuNE3hgzWCEImNp46QS5CyKnw5QUA==
-  dependencies:
-    "@glimmer/tracking" "^1.0.0"
-    ember-cli-babel "^7.26.6"
-    ember-cli-typescript "^4.2.1"
-    ember-tracked-storage-polyfill "1.0.0"
 
 tree-sync@^1.2.2:
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1310,7 +1310,7 @@
     "@handlebars/parser" "~2.0.0"
     simple-html-tokenizer "^0.5.11"
 
-"@glimmer/tracking@^1.0.4", "@glimmer/tracking@^1.1.2":
+"@glimmer/tracking@^1.0.0", "@glimmer/tracking@^1.0.4", "@glimmer/tracking@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-1.1.2.tgz#74e71be07b0a7066518d24044d2665d0cf8281eb"
   integrity sha512-cyV32zsHh+CnftuRX84ALZpd2rpbDrhLhJnTXn9W//QpqdRZ5rdMsxSY9fOsj0CKEc706tmEU299oNnDc0d7tA==
@@ -4744,7 +4744,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, em
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.10, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -4991,7 +4991,7 @@ ember-cli-typescript@^3.1.4:
     stagehand "^1.0.0"
     walk-sync "^2.0.0"
 
-ember-cli-typescript@^4.0.0:
+ember-cli-typescript@^4.0.0, ember-cli-typescript@^4.1.0, ember-cli-typescript@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz#54d08fc90318cc986f3ea562f93ce58a6cc4c24d"
   integrity sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==
@@ -5406,6 +5406,14 @@ ember-template-recast@^6.1.3:
     slash "^3.0.0"
     tmp "^0.2.1"
     workerpool "^6.1.5"
+
+ember-tracked-storage-polyfill@1.0.0, ember-tracked-storage-polyfill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/ember-tracked-storage-polyfill/-/ember-tracked-storage-polyfill-1.0.0.tgz"
+  integrity sha512-eL7lZat68E6P/D7b9UoTB5bB5Oh/0aju0Z7PCMi3aTwhaydRaxloE7TGrTRYU+NdJuyNVZXeGyxFxn2frvd3TA==
+  dependencies:
+    ember-cli-babel "^7.26.3"
+    ember-cli-htmlbars "^5.7.1"
 
 ember-truth-helpers@^3.0.0:
   version "3.0.0"
@@ -11322,6 +11330,26 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+tracked-built-ins@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tracked-built-ins/-/tracked-built-ins-2.0.1.tgz#9d6d0db29ad187e8533591f0e891e15b7a2259c5"
+  integrity sha512-v0DwPVNm3zA4cmJLpcBJxJfKefN6ldhkc8l5YA+cWHq7kI8WMUcXjIXgl/AIxmt1SoO1bwPdpikPRHHrIBDtFQ==
+  dependencies:
+    ember-cli-babel "^7.26.10"
+    ember-cli-typescript "^4.1.0"
+    ember-tracked-storage-polyfill "^1.0.0"
+    tracked-maps-and-sets "^3.0.2"
+
+tracked-maps-and-sets@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tracked-maps-and-sets/-/tracked-maps-and-sets-3.0.2.tgz#6ea1b9f2a367d24f2e9905b74b24437fbce76ea6"
+  integrity sha512-UIRcWsX1kDOcC/Q2R58weYWlw01EnmWWBwUv3okWS+zMBvsgIfYoO6veHhuNE3hgzWCEImNp46QS5CyKnw5QUA==
+  dependencies:
+    "@glimmer/tracking" "^1.0.0"
+    ember-cli-babel "^7.26.6"
+    ember-cli-typescript "^4.2.1"
+    ember-tracked-storage-polyfill "1.0.0"
 
 tree-sync@^1.2.2:
   version "1.4.0"


### PR DESCRIPTION
This refactors ember-node-tree to avoid mutating the node object passed in when user selects a node.

Mutating state passed violates the data down, actions up principle. Having a single owner for every state eases state management.

This merge request changes ember-node-tree to manage the `isSelected` state separately from the node passed in. It does so by using a `TrackedWeakSet`, which holds the nodes, which are selected. Using a `WeakSet` prevents memory leakage. Having it tracked eases change management with Glimmer VM by using autotracking. It is recommended pattern in Ember.js since Octane edition.

`tracked-built-ins` is currently user-land library. Adding it to default blueprints for new Ember applications is proposed in [RFC 812](https://github.com/emberjs/rfcs/pull/812). Feedback from core team indicates that it is likely that it will be added to blueprints soonish. Relying on it seems to be a safe bet.

This refactoring breaks the following tests:

- unselecting a parent node, unselects all child nodes
- selecting a parent node unselects previously selected child nodes 

But I'm not sure if that functionality is considered a feature or a bug. If it is a feature, I can update this implementation to support it as well. But wanted to clarify before.

Based on #33, which needs to be merged first.