### PR TITLE
[BREAKING] drop IE11 support

### DIFF
--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -9,10 +9,6 @@ const browsers = [
 const isCI = !!process.env.CI;
 const isProduction = process.env.EMBER_ENV === 'production';
 
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -6,9 +6,6 @@ const browsers = [
   'last 1 Safari versions',
 ];
 
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
 module.exports = {
   browsers,
 };


### PR DESCRIPTION
IE11 has been discontinued even by Microsoft. No need to support it anymore. Trying to do so prevents usage of `tracked-built-ins`, which relies on proxies.