### PR TITLE
[BREAKING] drop support for Ember < 3.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.24
           - ember-lts-3.28
           - ember-release
           - ember-beta

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 ## Compatibility
 
-* Ember.js v3.24 or above
-* Ember CLI v3.24 or above
+* Ember.js v3.28 or above
+* Ember CLI v3.28 or above
 * Node.js v14 or above
 
 


### PR DESCRIPTION
Tests for #35 break in Ember 3.24. The only consumer, which I'm aware of, is using Ember 3.28 anyways. Let drop support for older versions and not waste time on that one.